### PR TITLE
[COMMON] 도메인 생성

### DIFF
--- a/src/main/java/com/triplog/TriplogApplication.java
+++ b/src/main/java/com/triplog/TriplogApplication.java
@@ -2,7 +2,9 @@ package com.triplog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TriplogApplication {
 

--- a/src/main/java/com/triplog/common/domain/BaseEntity.java
+++ b/src/main/java/com/triplog/common/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.triplog.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/triplog/place/domain/BookMark.java
+++ b/src/main/java/com/triplog/place/domain/BookMark.java
@@ -1,0 +1,36 @@
+package com.triplog.place.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookMark extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+}

--- a/src/main/java/com/triplog/place/domain/Place.java
+++ b/src/main/java/com/triplog/place/domain/Place.java
@@ -1,0 +1,40 @@
+package com.triplog.place.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.place.domain.enums.Category;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private double latitude;
+
+    private double longitude;
+
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private Long kakaoMapId;
+}

--- a/src/main/java/com/triplog/place/domain/enums/Category.java
+++ b/src/main/java/com/triplog/place/domain/enums/Category.java
@@ -1,0 +1,15 @@
+package com.triplog.place.domain.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Category {
+
+    TOURIST_SPOT("관광지"),
+    RESTAURANT("음식점"),
+    CAFE_BAKERY("카페/베이커리"),
+    ACCOMMODATION("숙소"),
+    ETC("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/triplog/record/domain/Record.java
+++ b/src/main/java/com/triplog/record/domain/Record.java
@@ -1,0 +1,51 @@
+package com.triplog.record.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.place.domain.Place;
+import com.triplog.trip.domain.Trip;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Record extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    private String title;
+
+    private String memo;
+
+    private LocalDate date;
+
+    private boolean isPublic;
+}
+

--- a/src/main/java/com/triplog/record/domain/RecordImage.java
+++ b/src/main/java/com/triplog/record/domain/RecordImage.java
@@ -1,0 +1,34 @@
+package com.triplog.record.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "record_id")
+    private Record record;
+
+    private String imageUrl;
+}

--- a/src/main/java/com/triplog/record/domain/RecordTag.java
+++ b/src/main/java/com/triplog/record/domain/RecordTag.java
@@ -1,0 +1,33 @@
+package com.triplog.record.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "record_id")
+    private Record record;
+
+    private String content;
+}

--- a/src/main/java/com/triplog/trip/domain/Trip.java
+++ b/src/main/java/com/triplog/trip/domain/Trip.java
@@ -1,0 +1,36 @@
+package com.triplog.trip.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Trip extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String memo;
+
+    private boolean isPublic;
+
+    private LocalDate startDate;
+
+    private LocalDate end_Date;
+}

--- a/src/main/java/com/triplog/trip/domain/TripParticipant.java
+++ b/src/main/java/com/triplog/trip/domain/TripParticipant.java
@@ -1,0 +1,36 @@
+package com.triplog.trip.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripParticipant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+}

--- a/src/main/java/com/triplog/trip/domain/TripTag.java
+++ b/src/main/java/com/triplog/trip/domain/TripTag.java
@@ -1,0 +1,33 @@
+package com.triplog.trip.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+
+    private String content;
+}

--- a/src/main/java/com/triplog/user/domain/User.java
+++ b/src/main/java/com/triplog/user/domain/User.java
@@ -1,0 +1,40 @@
+package com.triplog.user.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.user.domain.enums.Gender;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String nickname;
+
+    private String email;
+
+    private String birthYear;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+}

--- a/src/main/java/com/triplog/user/domain/UserVibe.java
+++ b/src/main/java/com/triplog/user/domain/UserVibe.java
@@ -1,0 +1,37 @@
+package com.triplog.user.domain;
+
+import com.triplog.common.domain.BaseEntity;
+import com.triplog.user.domain.enums.Vibe;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserVibe extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private Vibe vibe;
+}

--- a/src/main/java/com/triplog/user/domain/enums/Gender.java
+++ b/src/main/java/com/triplog/user/domain/enums/Gender.java
@@ -1,0 +1,7 @@
+package com.triplog.user.domain.enums;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    NONE
+}

--- a/src/main/java/com/triplog/user/domain/enums/Vibe.java
+++ b/src/main/java/com/triplog/user/domain/enums/Vibe.java
@@ -1,0 +1,28 @@
+package com.triplog.user.domain.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Vibe {
+
+    WARM("따뜻한"),
+    COMFORTABLE("편안한"),
+    MELANCHOLIC("아늑한"),
+    CALM("잔잔한"),
+    JOYFUL("즐거운"),
+    NOISY("시끄러운"),
+    EXCITED("흥겨운"),
+    DREAMY("몽환적인"),
+    ROMANTIC("로맨틱한"),
+    SENSUAL("감성적인"),
+    BEAUTIFUL("아름다운"),
+    DARK("음산한"),
+    UNCOMFORTABLE("불편한"),
+    HEAVY("무거운"),
+    INTENSE("격렬한"),
+    FORMAL("격식있는"),
+    ETC("기타"),
+    NONE("해당없음");
+
+    private final String description;
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #1 

## 💻 작업 내용
- [x] 패키지 구조 설정 - 도메인형
- [x] 도메인 생성

## ✅ PR Point
- BaseEntity를 상속하여 전 테이블에 createdAt, updatedAt 필드 자동 관리 기능을 추가하였습니다.
- 엔티티 간 관계는 단방향 매핑만 적용하였고, 
양방향 매핑은 구현 과정에서 필요 시 추가하는 방식으로 진행하면 좋을 것 같습니다.
- H2 예약어 충돌을 피하기 위해 user 테이블명을 users로 지정하였습니다.
(추후 테스트 코드 작성 시 H2 사용 가능성 고려)
- 카카오에서 제공하는 birthyear 값 형식을 고려하여, 우선 user 엔티티의 출생 연도 필드는 String 타입으로 처리하였습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
테이블 생성 확인
<img width="760" alt="스크린샷 2025-04-30 오후 4 42 46" src="https://github.com/user-attachments/assets/40e6b6c6-8c59-4173-85e3-dc2a39c551da" />