### PR TITLE
[COMMON] Custom Exception 설정

### DIFF
--- a/src/main/java/com/triplog/common/exception/CustomException.java
+++ b/src/main/java/com/triplog/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.triplog.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/triplog/common/exception/ErrorCode.java
+++ b/src/main/java/com/triplog/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 	// Record
 
 	// Place
+	PLACE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 장소 정보입니다."),
 
 	// JWT
 	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/triplog/common/exception/ErrorCode.java
+++ b/src/main/java/com/triplog/common/exception/ErrorCode.java
@@ -1,0 +1,40 @@
+package com.triplog.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+	//Internal Server Error
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 생겼습니다."),
+
+	// Client Error
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "적절하지 않은 HTTP 메소드입니다."),
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "요청 값의 타입이 잘못되었습니다."),
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "적절하지 않은 값입니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리소스를 찾을 수 없습니다."),
+	MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+
+	// User
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다."),
+
+	// Trip
+
+	// Record
+
+	// Place
+
+	// JWT
+	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+	TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰 정보를 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	ErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/triplog/common/exception/ErrorResponse.java
+++ b/src/main/java/com/triplog/common/exception/ErrorResponse.java
@@ -12,25 +12,19 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
 
-    private LocalDateTime time;
     private HttpStatus status;
     private String message;
-    private String requestURI;
 
     @Builder
-    private ErrorResponse(LocalDateTime time, HttpStatus status, String message, String requestURI) {
-        this.time = time;
+    private ErrorResponse(HttpStatus status, String message) {
         this.status = status;
         this.message = message;
-        this.requestURI = requestURI;
     }
 
-    public static ErrorResponse of(ErrorCode errorCode, String requestURI) {
+    public static ErrorResponse of(ErrorCode errorCode) {
         return ErrorResponse.builder()
-                .time(LocalDateTime.now())
                 .status(errorCode.getStatus())
                 .message(errorCode.getMessage())
-                .requestURI(requestURI)
                 .build();
     }
 }

--- a/src/main/java/com/triplog/common/exception/ErrorResponse.java
+++ b/src/main/java/com/triplog/common/exception/ErrorResponse.java
@@ -1,0 +1,36 @@
+package com.triplog.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+
+    private LocalDateTime time;
+    private HttpStatus status;
+    private String message;
+    private String requestURI;
+
+    @Builder
+    private ErrorResponse(LocalDateTime time, HttpStatus status, String message, String requestURI) {
+        this.time = time;
+        this.status = status;
+        this.message = message;
+        this.requestURI = requestURI;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String requestURI) {
+        return ErrorResponse.builder()
+                .time(LocalDateTime.now())
+                .status(errorCode.getStatus())
+                .message(errorCode.getMessage())
+                .requestURI(requestURI)
+                .build();
+    }
+}

--- a/src/main/java/com/triplog/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/triplog/common/exception/GlobalExceptionHandler.java
@@ -21,99 +21,99 @@ public class GlobalExceptionHandler {
 
 	// 500 : Internal Server Error
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorResponse> handleServerException(Exception e, HttpServletRequest request) {
+	public ResponseEntity<ErrorResponse> handleServerException(Exception e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// 404 : Not Found
 	@ExceptionHandler(NoResourceFoundException.class)
 	protected ResponseEntity<ErrorResponse> handleNoResourceFoundExceptionException(
-		NoResourceFoundException e, HttpServletRequest request) {
+		NoResourceFoundException e) {
 		log.error(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// 405 : Method Not Allowed
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
-		HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+		HttpRequestMethodNotSupportedException e) {
 		log.error(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// 400 : MethodArgumentNotValidException
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
-		MethodArgumentNotValidException e, HttpServletRequest request) {
+		MethodArgumentNotValidException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// 400 : MethodArgumentType
 	@ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
 	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
-		MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+		MethodArgumentTypeMismatchException e) {
 		log.error(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// 400 : Bad Request, ModelAttribute
 	@ExceptionHandler(BindException.class)
-	public ResponseEntity<ErrorResponse> handleBindException(BindException e, HttpServletRequest request) {
+	public ResponseEntity<ErrorResponse> handleBindException(BindException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
-		HttpMessageNotReadableException e, HttpServletRequest request) {
+		HttpMessageNotReadableException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e, HttpServletRequest request) {
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	@ExceptionHandler(NoHandlerFoundException.class)
-	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e, HttpServletRequest request) {
+	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
-		MissingServletRequestParameterException e, HttpServletRequest request) {
+		MissingServletRequestParameterException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// 유효성 검사 에러
 	@ExceptionHandler(HandlerMethodValidationException.class)
-	public ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException e, HttpServletRequest request) {
+	public ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 
 	// Custom Exception
 	@ExceptionHandler(CustomException.class)
-	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
 		log.warn(e.getMessage(), e);
-		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request.getRequestURI());
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
 		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
 	}
 }

--- a/src/main/java/com/triplog/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/triplog/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,119 @@
+package com.triplog.common.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// 500 : Internal Server Error
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleServerException(Exception e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// 404 : Not Found
+	@ExceptionHandler(NoResourceFoundException.class)
+	protected ResponseEntity<ErrorResponse> handleNoResourceFoundExceptionException(
+		NoResourceFoundException e, HttpServletRequest request) {
+		log.error(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// 405 : Method Not Allowed
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+		log.error(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// 400 : MethodArgumentNotValidException
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// 400 : MethodArgumentType
+	@ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+		MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+		log.error(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// 400 : Bad Request, ModelAttribute
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ErrorResponse> handleBindException(BindException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+		MissingServletRequestParameterException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// 유효성 검사 에러
+	@ExceptionHandler(HandlerMethodValidationException.class)
+	public ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+
+	// Custom Exception
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request.getRequestURI());
+		return ResponseEntity.status(errorResponse.getStatus().value()).body(errorResponse);
+	}
+}

--- a/src/main/java/com/triplog/place/PlaceController.java
+++ b/src/main/java/com/triplog/place/PlaceController.java
@@ -1,0 +1,30 @@
+package com.triplog.place;
+import com.triplog.place.dto.PlaceSaveRequest;
+import com.triplog.place.dto.PlaceSaveResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/places")
+@RequiredArgsConstructor
+@Slf4j
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    // 장소 등록
+    @PostMapping
+    public ResponseEntity<PlaceSaveResponse> save(@RequestBody @Valid PlaceSaveRequest request) {
+
+        PlaceSaveResponse response = placeService.save(request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/triplog/place/PlaceRepository.java
+++ b/src/main/java/com/triplog/place/PlaceRepository.java
@@ -1,0 +1,9 @@
+package com.triplog.place;
+
+import com.triplog.place.domain.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    boolean existsByNameAndAddress(String name, String Address);
+}

--- a/src/main/java/com/triplog/place/PlaceService.java
+++ b/src/main/java/com/triplog/place/PlaceService.java
@@ -1,0 +1,42 @@
+package com.triplog.place;
+
+import com.triplog.common.exception.CustomException;
+import com.triplog.common.exception.ErrorCode;
+import com.triplog.place.domain.Place;
+import com.triplog.place.dto.PlaceSaveRequest;
+import com.triplog.place.dto.PlaceSaveResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+
+    @Transactional
+    public PlaceSaveResponse save(PlaceSaveRequest request) {
+
+        // 중복 체크 : 이름과 장소가 모두 일치하는 장소가 이미 DB에 있는 경우, 에러를 반환한다.
+        boolean isExistingPlace = placeRepository.existsByNameAndAddress(request.name(), request.address());
+
+        if(isExistingPlace) {
+            throw new CustomException(ErrorCode.PLACE_ALREADY_EXISTS);
+        }
+
+        Place place = Place.builder()
+                .name(request.name())
+                .address(request.address())
+                .build();
+
+        Place savedPlace = placeRepository.save(place);
+
+        return PlaceSaveResponse.builder()
+                .placeId(savedPlace.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/triplog/place/dto/PlaceSaveRequest.java
+++ b/src/main/java/com/triplog/place/dto/PlaceSaveRequest.java
@@ -1,0 +1,3 @@
+package com.triplog.place.dto;
+
+public record PlaceSaveRequest(String name, String address) {}

--- a/src/main/java/com/triplog/place/dto/PlaceSaveResponse.java
+++ b/src/main/java/com/triplog/place/dto/PlaceSaveResponse.java
@@ -1,0 +1,6 @@
+package com.triplog.place.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlaceSaveResponse(Long placeId) {}


### PR DESCRIPTION
## 🔥 Related Issues
- close #5 

## 💻 작업 내용
- [x] Custom Exception, GlobalExceptionHandler 설정
- [x] 사용 예시(장소 생성 API) 추가

## ✅ PR Point(사용법)
1️⃣  ErrorCode에 예외 상황에 대한 에러 코드(메시지, 상태 코드 포함) 추가
(이미 존재한다면 재사용하기)
```java
public enum ErrorCode {

	//Internal Server Error
	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 생겼습니다."),

	// Client Error
	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "적절하지 않은 HTTP 메소드입니다."),
	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "요청 값의 타입이 잘못되었습니다."),
	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "적절하지 않은 값입니다."),
	NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리소스를 찾을 수 없습니다."),
	MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),

	// User
	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다."),

	// Trip
        ...
```

2️⃣ 예외 발생 구간에서 throw로 예외 던지기 
→ `@ExceptionHandler`(GlobalExceptionHandler 클래스)에 의해 자동으로 에러 응답 처리되므로, Controller에서 별도 분기 처리 불필요
- Service (예외 발생 지점)
  ```java
  @Transactional
  public PlaceSaveResponse save(PlaceSaveRequest request) {
  
      // 중복 체크 : 이름과 장소가 모두 일치하는 장소가 이미 DB에 있는 경우, 에러를 반환한다.
      boolean isExistingPlace = placeRepository.existsByNameAndAddress(request.name(), request.address());
  
      if(isExistingPlace) {
          throw new CustomException(ErrorCode.PLACE_ALREADY_EXISTS);
      }
      ...
  ```
- Controller : 정상(성공) 흐름만 처리
  ```java
  @PostMapping
  public ResponseEntity<PlaceSaveResponse> save(@RequestBody @Valid PlaceSaveRequest request) {
  
      PlaceSaveResponse response = placeService.save(request);
  
      return ResponseEntity.ok(response);
  }
  ```

## ☀️ 스크린샷 / GIF / 화면 녹화
1️⃣ 장소 등록(성공)
<img width="764" alt="스크린샷 2025-05-04 오후 3 35 44" src="https://github.com/user-attachments/assets/b5ad855c-8bbc-40e5-aacf-5e30f01e8f2b" />

2️⃣ 장소 재등록(같은 정보 👉 실패)
<img width="765" alt="스크린샷 2025-05-04 오후 9 39 22" src="https://github.com/user-attachments/assets/9c7f3d32-e0bc-43aa-b632-75dd267aeeb7" />