### PR TITLE
[USER] 회원정보 수정 API 

### DIFF
--- a/src/main/java/com/triplog/common/exception/ErrorCode.java
+++ b/src/main/java/com/triplog/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
 	// User
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다."),
+	DUPLICATE_USER(HttpStatus.CONFLICT,"존재하는 닉네임 입니다."),
 
 	// Trip
 

--- a/src/main/java/com/triplog/user/controller/UserController.java
+++ b/src/main/java/com/triplog/user/controller/UserController.java
@@ -2,20 +2,22 @@ package com.triplog.user.controller;
 
 import com.triplog.user.dto.LoginRequestDto;
 import com.triplog.user.dto.SignupRequestDto;
+import com.triplog.user.dto.UpdateProfileRequestDto;
 import com.triplog.user.jwt.JwtToken;
+import com.triplog.user.jwt.JwtUtil;
 import com.triplog.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class UserController {
     private final UserService userService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody SignupRequestDto request) {
@@ -27,5 +29,14 @@ public class UserController {
     public ResponseEntity<JwtToken> login(@RequestBody LoginRequestDto request) {
         String token = userService.login(request);
         return ResponseEntity.ok(JwtToken.builder().accessToken(token).build());
+    }
+
+    @PutMapping("/users")
+    public ResponseEntity<String> updateProfile(HttpServletRequest request, @RequestBody UpdateProfileRequestDto dto) {
+        String token=jwtUtil.resolveToken(request);
+        String nickname=jwtUtil.extractNickName(token);
+        userService.updateProfile(nickname,dto);
+        return ResponseEntity.ok("회원 정보가 수정되었습니다.");
+
     }
 }

--- a/src/main/java/com/triplog/user/controller/UserController.java
+++ b/src/main/java/com/triplog/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.triplog.user.controller;
 import com.triplog.user.dto.LoginRequestDto;
 import com.triplog.user.dto.SignupRequestDto;
 import com.triplog.user.dto.UpdateProfileRequestDto;
+import com.triplog.user.jwt.CustomUserDetails;
 import com.triplog.user.jwt.JwtToken;
 import com.triplog.user.jwt.JwtUtil;
 import com.triplog.user.service.UserService;
@@ -32,9 +33,8 @@ public class UserController {
     }
 
     @PutMapping("/users")
-    public ResponseEntity<String> updateProfile(HttpServletRequest request, @RequestBody UpdateProfileRequestDto dto) {
-        String token=jwtUtil.resolveToken(request);
-        String nickname=jwtUtil.extractNickName(token);
+    public ResponseEntity<String> updateProfile(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UpdateProfileRequestDto dto) {
+        String nickname = userDetails.getUsername();
         userService.updateProfile(nickname,dto);
         return ResponseEntity.ok("회원 정보가 수정되었습니다.");
 

--- a/src/main/java/com/triplog/user/domain/User.java
+++ b/src/main/java/com/triplog/user/domain/User.java
@@ -37,4 +37,8 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/triplog/user/dto/UpdateProfileRequestDto.java
+++ b/src/main/java/com/triplog/user/dto/UpdateProfileRequestDto.java
@@ -1,0 +1,11 @@
+package com.triplog.user.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateProfileRequestDto {
+    private String nickname;
+    private List<String> vibe;
+}

--- a/src/main/java/com/triplog/user/jwt/CustomUserDetailService.java
+++ b/src/main/java/com/triplog/user/jwt/CustomUserDetailService.java
@@ -1,0 +1,25 @@
+package com.triplog.user.jwt;
+
+import com.triplog.common.exception.CustomException;
+import com.triplog.common.exception.ErrorCode;
+import com.triplog.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public CustomUserDetailService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String nickname){
+        return userRepository.findByNickname(nickname)
+                .map(CustomUserDetails::new)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/triplog/user/jwt/CustomUserDetails.java
+++ b/src/main/java/com/triplog/user/jwt/CustomUserDetails.java
@@ -1,0 +1,34 @@
+package com.triplog.user.jwt;
+
+import com.triplog.user.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+    public User getUser() {
+        return user;
+    }
+    @Override
+    public String getUsername(){
+        return user.getNickname();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override public String getPassword() { return null; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/triplog/user/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/triplog/user/jwt/JwtAuthFilter.java
@@ -23,6 +23,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
+    private final CustomUserDetailService customUserDetailService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
@@ -45,10 +46,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String nickName = jwtUtil.extractNickName(token);
 
         if (nickName != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = User.withUsername(nickName)
-                    .password("")
-                    .roles("USER")
-                    .build();
+            UserDetails userDetails = customUserDetailService.loadUserByUsername(nickName);
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/triplog/user/jwt/JwtUtil.java
+++ b/src/main/java/com/triplog/user/jwt/JwtUtil.java
@@ -5,6 +5,7 @@ import com.triplog.user.dto.LoginRequestDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -75,11 +76,11 @@ public class JwtUtil {
         return false;
     }
 
-    public Claims parseClaims(String accessToken){
-        try{
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
-        }catch (ExpiredJwtException e){
-            return e.getClaims();
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 제거
         }
+        return null;
     }
 }

--- a/src/main/java/com/triplog/user/repository/UserRepository.java
+++ b/src/main/java/com/triplog/user/repository/UserRepository.java
@@ -4,9 +4,11 @@ import com.triplog.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findByNickname(String nickname);
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/triplog/user/repository/UserVibeRepository.java
+++ b/src/main/java/com/triplog/user/repository/UserVibeRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface UserVibeRepository extends JpaRepository<UserVibe,Long> {
     List<UserVibe> findByUser(User user);
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/triplog/user/service/UserService.java
+++ b/src/main/java/com/triplog/user/service/UserService.java
@@ -7,11 +7,13 @@ import com.triplog.user.domain.UserVibe;
 import com.triplog.user.domain.enums.Vibe;
 import com.triplog.user.dto.LoginRequestDto;
 import com.triplog.user.dto.SignupRequestDto;
+import com.triplog.user.dto.UpdateProfileRequestDto;
 import com.triplog.user.jwt.JwtUtil;
 import com.triplog.user.repository.UserRepository;
 import com.triplog.user.repository.UserVibeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -59,4 +61,29 @@ public class UserService {
         return accessToken;
     }
 
+    @Transactional
+    public void updateProfile(String nickname, UpdateProfileRequestDto updateProfileRequestDto) {
+        User user=userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if(updateProfileRequestDto.getNickname()!=null && !updateProfileRequestDto.getNickname().equals(nickname)) {
+            if(userRepository.existsByNickname(updateProfileRequestDto.getNickname())) {
+                throw new CustomException(ErrorCode.DUPLICATE_USER);
+            }
+            user.updateNickname(updateProfileRequestDto.getNickname());
+        }
+
+        if(updateProfileRequestDto.getVibe()!=null && !updateProfileRequestDto.getVibe().isEmpty()) {
+            userVibeRepository.deleteAllByUser(user);
+
+            for(String vibeDesc : updateProfileRequestDto.getVibe()) {
+                Vibe vibeEnum = Vibe.fromDescription(vibeDesc);
+                UserVibe userVibe=UserVibe.builder()
+                        .user(user)
+                        .vibe(vibeEnum)
+                        .build();
+                userVibeRepository.save(userVibe);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #7 

## 💻 작업 내용
- [x] ~ jwt 토큰으로 유저 정보 가져오기
- [x] ~ 닉네임, 분위기 입력받아 해당 유저 db 업데이트

## ✅ PR Point
- Controller에서 @AuthenticationPrincipal CustomUserDetails로 유저 정보를 받아옵니다.
- jwtUtil의 extractNickName로 nickname 추출 후 user 정보 확인했습니다.
- SignupRequestDto와 필드들은 같으나, 용도와 의미가 명확히 달라 UpdateProfileRequestDto를 새로 만들어 유지보수 쉽도록 구현하였습니다.
- 새로 입력한 닉네임이 다른 유저랑 같을 수 있어 ErrorCode에 DUPLICATE_USER 추가하여 에러처리 하였습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
1. 회원정보 수정 
<img width="828" alt="image" src="https://github.com/user-attachments/assets/48aa9323-1b40-404a-a757-6fed95a5a3e6" />

2. DB 
<img width="662" alt="image" src="https://github.com/user-attachments/assets/5da04316-587c-477d-ae04-d0d380aefb2c" />

3. 이미 다른 회원이 쓰고 있는 닉네임으로 변경 시 
<img width="856" alt="image" src="https://github.com/user-attachments/assets/e2b4b1f1-d48f-4ca5-a365-a850e192396f" />

