### PR TITLE
[USER] 닉네임 중복 확인

### DIFF
--- a/src/main/java/com/triplog/user/controller/UserController.java
+++ b/src/main/java/com/triplog/user/controller/UserController.java
@@ -32,11 +32,18 @@ public class UserController {
         return ResponseEntity.ok(JwtToken.builder().accessToken(token).build());
     }
 
-    @PutMapping("/users")
+    @PatchMapping("/users")
     public ResponseEntity<String> updateProfile(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UpdateProfileRequestDto dto) {
         String nickname = userDetails.getUsername();
         userService.updateProfile(nickname,dto);
         return ResponseEntity.ok("회원 정보가 수정되었습니다.");
 
     }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
+        userService.checkNickname(nickname);
+        return ResponseEntity.ok("사용가능한 닉네임입니다.");
+    }
+
 }

--- a/src/main/java/com/triplog/user/jwt/SecurityConfig.java
+++ b/src/main/java/com/triplog/user/jwt/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/signup", "/api/login").permitAll()
+                        .requestMatchers("/api/signup", "/api/login","/api/check-nickname").permitAll()
                         .anyRequest().authenticated() //나머지는 요청 인증 필요
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/triplog/user/service/UserService.java
+++ b/src/main/java/com/triplog/user/service/UserService.java
@@ -86,4 +86,8 @@ public class UserService {
             }
         }
     }
+
+    public void checkNickname(String nickname) {
+        if(userRepository.findByNickname(nickname).isPresent()) throw new CustomException(ErrorCode.DUPLICATE_USER);
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #11 

## 💻 작업 내용
- [x] ~ 닉네임 중복 확인 api 구현
- [x] ~ 중복 시 에러처리 

## ✅ PR Point
- 회원가입시에 닉네임 중복 처리하는거라 spring security에 /api/check-name도 추가했습니다.
- 닉네임 받아서 중복 확인하고 중복이면 CustomException(ErrorCode.DUPLICATE_USER) 처리했습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
1. 입력받은 닉네임이 중복일 경우
<img width="861" alt="스크린샷 2025-05-06 15 44 15" src="https://github.com/user-attachments/assets/d5361869-ae8d-4736-8313-c3afd427336b" />

2. 사용가능한 경우
<img width="863" alt="스크린샷 2025-05-06 15 44 32" src="https://github.com/user-attachments/assets/e8545d55-329c-4e48-b6d8-e4ba9dabfd39" />
