### PR TITLE
[COMMON] Swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
+	id 'org.springframework.boot' version '3.3.6'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -40,6 +40,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/triplog/Bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/triplog/Bookmark/controller/BookmarkController.java
@@ -4,6 +4,8 @@ import com.triplog.Bookmark.service.BookmarkService;
 import com.triplog.Bookmark.dto.BookmarkDeleteRequest;
 import com.triplog.Bookmark.dto.BookmarkSaveRequest;
 import com.triplog.user.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/bookmarks")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Bookmark", description = "Bookmark 관련 API입니다.")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
     @PostMapping
+    @Operation(summary = "북마크 생성", description = "카카오 장소 id를 기반으로 해당 장소에 대한 북마크를 생성합니다.")
     public ResponseEntity<Void> create(@AuthenticationPrincipal CustomUserDetails userDetails,
                                        @RequestBody @Valid BookmarkSaveRequest request) {
 
@@ -34,6 +38,7 @@ public class BookmarkController {
     }
 
     @DeleteMapping
+    @Operation(summary = "북마크 삭제", description = "카카오 장소 id를 기반으로 해당 장소에 대한 북마크를 삭제합니다.")
     public ResponseEntity<Void> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
                                        @RequestBody @Valid BookmarkDeleteRequest request) {
 

--- a/src/main/java/com/triplog/Bookmark/dto/BookmarkDeleteRequest.java
+++ b/src/main/java/com/triplog/Bookmark/dto/BookmarkDeleteRequest.java
@@ -1,4 +1,9 @@
 package com.triplog.Bookmark.dto;
 
-public record BookmarkDeleteRequest(Long kakaoPlaceId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BookmarkDeleteRequest(
+        @Schema(description = "카카오 장소 id", nullable = false, example = "1")
+        Long kakaoPlaceId
+) {
 }

--- a/src/main/java/com/triplog/Bookmark/dto/BookmarkSaveRequest.java
+++ b/src/main/java/com/triplog/Bookmark/dto/BookmarkSaveRequest.java
@@ -1,3 +1,8 @@
 package com.triplog.Bookmark.dto;
 
-public record BookmarkSaveRequest(Long kakaoPlaceId) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BookmarkSaveRequest(
+        @Schema(description = "카카오 장소 id", nullable = false, example = "1")
+        Long kakaoPlaceId
+) {}

--- a/src/main/java/com/triplog/common/config/SwaggerConfig.java
+++ b/src/main/java/com/triplog/common/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.triplog.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // Bearer Token을 위한 SecurityScheme 정의
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        // SecurityRequirement 정의
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("weve API")
+                        .description("weve API입니다.")
+                        .version("1.0.0"))
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(securityRequirement);
+    }
+}

--- a/src/main/java/com/triplog/place/controller/PlaceController.java
+++ b/src/main/java/com/triplog/place/controller/PlaceController.java
@@ -2,6 +2,7 @@ package com.triplog.place.controller;
 import com.triplog.place.service.PlaceService;
 import com.triplog.place.dto.PlaceSaveRequest;
 import com.triplog.place.dto.PlaceSaveResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/places")
 @RequiredArgsConstructor
 @Slf4j
+@Hidden
 public class PlaceController {
 
     private final PlaceService placeService;

--- a/src/main/java/com/triplog/user/controller/UserController.java
+++ b/src/main/java/com/triplog/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.triplog.user.jwt.CustomUserDetails;
 import com.triplog.user.jwt.JwtToken;
 import com.triplog.user.jwt.JwtUtil;
 import com.triplog.user.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "User", description = "User 관련 API입니다.")
 public class UserController {
     private final UserService userService;
     private final JwtUtil jwtUtil;

--- a/src/main/java/com/triplog/user/jwt/SecurityConfig.java
+++ b/src/main/java/com/triplog/user/jwt/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/signup", "/api/login","/api/check-nickname").permitAll()
+                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated() //나머지는 요청 인증 필요
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 🔥 Related Issues
- close #15 

## 💻 작업 내용
- [x] SwaggerConfig 생성
- [x] Swagger 연동(controller, dto)

## ✅ PR Point
- Tag 관련 설정: 통일성을 위해 현존하는 Controller 상단에 다음과 같이 `@tag`를 설정했습니다.
`@Tag(name = "{domain}", description = "{domain} 관련 API입니다.")`
- 기타 설정: 각 API 설정은 담당자가 직접 하면 좋을 것 같습니다.
- Swagger 접속 에러 해결: Swagger 접속 문제를 해결하기 위해, 스프링부트 버전을 3.4.2에서 3.3.6으로 낮추었습니다. (하단 레퍼런스 참고)

## 📚 Reference
- [[트러블슈팅] Swagger 500 에러: Failed to load API definition](https://dev-meung.tistory.com/entry/%ED%95%B4%EC%BB%A4%ED%86%A4-HY-THON-%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85-Swagger-500-%EC%97%90%EB%9F%AC-Failed-to-load-API-definition)