### PR TITLE
[TRIP] 여행 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/triplog/trip/TripController.java
+++ b/src/main/java/com/triplog/trip/TripController.java
@@ -1,6 +1,7 @@
 package com.triplog.trip;
 import com.triplog.trip.dto.TripCreateRequest;
 import com.triplog.trip.dto.TripCreateResponse;
+import com.triplog.trip.dto.TripFindByUserResponse;
 import com.triplog.user.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,4 +29,12 @@ public class TripController {
         TripCreateResponse response = tripService.createTrip(request, username);
         return ResponseEntity.ok(response);
     }
- }
+
+    @GetMapping("/users/trips")
+    @Operation(summary = "여행 목록 조회", description = "사용자의 여행 목록을 조회합니다.")
+    public ResponseEntity<TripFindByUserResponse> getTripsByUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        String username = userDetails.getUsername();
+        TripFindByUserResponse response = tripService.getTripsByUser(username);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/triplog/trip/TripController.java
+++ b/src/main/java/com/triplog/trip/TripController.java
@@ -1,31 +1,31 @@
 package com.triplog.trip;
-import com.triplog.place.dto.PlaceSaveResponse;
 import com.triplog.trip.dto.TripCreateRequest;
 import com.triplog.trip.dto.TripCreateResponse;
 import com.triplog.user.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Trip", description = "Trip 관련 API입니다.")
 public class TripController {
 
     private final TripService tripService;
 
     @PostMapping("/users/trips")
+    @Operation(summary = "여행 생성", description = "여행에 대한 정보를 입력받고 새로 생성합니다.")
     public ResponseEntity<TripCreateResponse> createTrip(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody @Valid TripCreateRequest request) {
-        Long userId = userDetails.getUser().getId();
-        TripCreateResponse response = tripService.createTrip(request, userId);
+        String username = userDetails.getUsername();
+        TripCreateResponse response = tripService.createTrip(request, username);
         return ResponseEntity.ok(response);
     }
-}
+ }

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -2,6 +2,8 @@ package com.triplog.trip;
 
 import com.triplog.trip.domain.Trip;
 import com.triplog.trip.domain.TripParticipant;
+import com.triplog.trip.domain.TripTag;
+import com.triplog.trip.repository.TripTagRepository;
 import com.triplog.user.domain.User;
 import com.triplog.trip.dto.TripCreateRequest;
 import com.triplog.trip.dto.TripCreateResponse;
@@ -12,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 
 @Slf4j
@@ -22,6 +23,7 @@ import java.util.List;
 public class TripService {
     private final TripRepository tripRepository;
     private final TripParticipantRepository tripParticipantRepository;
+    private final TripTagRepository tripTagRepository;
     private final UserFinder userFinder;
 
 
@@ -45,6 +47,15 @@ public class TripService {
                 .build();
 
         tripParticipantRepository.save(participant);
+
+        List<String> tripTagContents = request.tags();
+        for(String tripTagContent:tripTagContents){
+            TripTag tripTag = TripTag.builder()
+                    .trip(savedTrip)
+                    .content(tripTagContent)
+                    .build();
+            tripTagRepository.save(tripTag);
+        }
 
         return TripCreateResponse.builder()
                 .tripId(savedTrip.getId())

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -3,6 +3,7 @@ package com.triplog.trip;
 import com.triplog.trip.domain.Trip;
 import com.triplog.trip.domain.TripParticipant;
 import com.triplog.trip.domain.TripTag;
+import com.triplog.trip.dto.TripFindByUserResponse;
 import com.triplog.trip.repository.TripTagRepository;
 import com.triplog.user.domain.User;
 import com.triplog.trip.dto.TripCreateRequest;
@@ -59,6 +60,24 @@ public class TripService {
 
         return TripCreateResponse.builder()
                 .tripId(savedTrip.getId())
+                .build();
+    }
+
+    public TripFindByUserResponse getTripsByUser(String username) {
+        User user = userFinder.findByNickname(username);
+
+        List<TripParticipant> participationList = tripParticipantRepository.findByUser(user);
+
+        List<TripFindByUserResponse.Item> responseItems = participationList.stream()
+                .map(participant -> {
+                    Trip trip = participant.getTrip();
+                    List<TripTag> tags = tripTagRepository.findByTrip(trip);
+                    return TripFindByUserResponse.Item.from(trip, tags);
+                })
+                .toList();
+
+        return TripFindByUserResponse.builder()
+                .trips(responseItems)
                 .build();
     }
 

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -1,7 +1,5 @@
 package com.triplog.trip;
 
-import com.triplog.common.exception.CustomException;
-import com.triplog.common.exception.ErrorCode;
 import com.triplog.trip.domain.Trip;
 import com.triplog.trip.domain.TripParticipant;
 import com.triplog.user.domain.User;
@@ -9,11 +7,13 @@ import com.triplog.trip.dto.TripCreateRequest;
 import com.triplog.trip.dto.TripCreateResponse;
 import com.triplog.trip.repository.TripParticipantRepository;
 import com.triplog.trip.repository.TripRepository;
-import com.triplog.user.repository.UserRepository;
+import com.triplog.user.UserFinder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -22,13 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class TripService {
     private final TripRepository tripRepository;
     private final TripParticipantRepository tripParticipantRepository;
-    private final UserRepository userRepository;
+    private final UserFinder userFinder;
 
 
     @Transactional
-    public TripCreateResponse createTrip(TripCreateRequest request, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    public TripCreateResponse createTrip(TripCreateRequest request, String username) {
+        User user = userFinder.findByNickname(username);
 
         Trip trip = Trip.builder()
                 .title(request.title())

--- a/src/main/java/com/triplog/trip/dto/TripCreateRequest.java
+++ b/src/main/java/com/triplog/trip/dto/TripCreateRequest.java
@@ -1,5 +1,6 @@
 package com.triplog.trip.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
-public record TripCreateRequest (String title, String memo, boolean isPublic, LocalDate startDate, LocalDate endDate){ }
+public record TripCreateRequest (String title, String memo, boolean isPublic, LocalDate startDate, LocalDate endDate, List<String> tags){ }

--- a/src/main/java/com/triplog/trip/dto/TripFindByUserResponse.java
+++ b/src/main/java/com/triplog/trip/dto/TripFindByUserResponse.java
@@ -1,0 +1,34 @@
+package com.triplog.trip.dto;
+
+import com.triplog.trip.domain.Trip;
+import com.triplog.trip.domain.TripTag;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record TripFindByUserResponse (List<Item> trips) {
+    @Builder
+    public record Item(
+            Long tripId,
+            String title,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<String> tags
+    ) {
+        public static Item from(Trip trip, List<TripTag> tags) {
+            List<String> tagList = tags.stream()
+                    .map(TripTag::getContent)
+                    .toList();
+
+            return Item.builder()
+                    .tripId(trip.getId())
+                    .title(trip.getTitle())
+                    .startDate(trip.getStartDate())
+                    .endDate(trip.getEndDate())
+                    .tags(tagList)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/triplog/trip/repository/TripParticipantRepository.java
+++ b/src/main/java/com/triplog/trip/repository/TripParticipantRepository.java
@@ -1,7 +1,11 @@
 package com.triplog.trip.repository;
 
 import com.triplog.trip.domain.TripParticipant;
+import com.triplog.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TripParticipantRepository extends JpaRepository<TripParticipant, Long> {
+    List<TripParticipant> findByUser(User user);
 }

--- a/src/main/java/com/triplog/trip/repository/TripTagRepository.java
+++ b/src/main/java/com/triplog/trip/repository/TripTagRepository.java
@@ -1,0 +1,7 @@
+package com.triplog.trip.repository;
+
+import com.triplog.trip.domain.TripTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripTagRepository extends JpaRepository<TripTag, Long> {
+}

--- a/src/main/java/com/triplog/trip/repository/TripTagRepository.java
+++ b/src/main/java/com/triplog/trip/repository/TripTagRepository.java
@@ -1,7 +1,11 @@
 package com.triplog.trip.repository;
 
+import com.triplog.trip.domain.Trip;
 import com.triplog.trip.domain.TripTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TripTagRepository extends JpaRepository<TripTag, Long> {
+    List<TripTag> findByTrip(Trip trip);
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #32

## 💻 작업 내용
- [x] ~ 여행 생성 시 UserFinder 사용해서 에러 처리하도록 수정
- [x] ~ 여행 생성 시 태그 추가하도록 수정
- [x] ~ 여행 목록 조회 API 구현

## ✅ PR Point
- 이전 피드백을 반영하여 여행 생성 시 유저 관련 에러 처리 방법을 수정하였습니다.
- 여행 생성 시 여행 태그 추가 기능이 누락되어 추가하였습니다.
- 여행 목록 조회 시 record 가져오기 부분은 추후 구현하도록 하겠습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
1. 여행 생성
![image](https://github.com/user-attachments/assets/3574b7e1-6077-49e3-b557-0cf9c6364161)
![image](https://github.com/user-attachments/assets/f9235b65-74e4-4bb0-b3a9-6832f3fdc560)
![image](https://github.com/user-attachments/assets/8f056a2d-d4a8-4275-879a-b9cc096f0d57)

2. 여행 목록 조회
<img width="583" alt="image" src="https://github.com/user-attachments/assets/504eed75-9219-4ae4-aa69-656dde862c57" />