### PR TITLE
[TRIP] 동반자 초대 API 구현

### DIFF
--- a/src/main/java/com/triplog/common/exception/ErrorCode.java
+++ b/src/main/java/com/triplog/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 	TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "여행 정보를 찾을 수 없습니다."),
 	ALREADY_INVITED(HttpStatus.CONFLICT, "이미 초대된 사용자입니다."),
 	CANNOT_INVITE_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 초대할 수 없습니다."),
+	UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "이 여행에 대해 초대할 권한이 없습니다."),
 
 	// Record
 	RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"기록 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/triplog/common/exception/ErrorCode.java
+++ b/src/main/java/com/triplog/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
 	// Trip
 	TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "여행 정보를 찾을 수 없습니다."),
+	ALREADY_INVITED(HttpStatus.CONFLICT, "이미 초대된 사용자입니다."),
 
 	// Record
 	RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"기록 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/triplog/common/exception/ErrorCode.java
+++ b/src/main/java/com/triplog/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 	// Trip
 	TRIP_NOT_FOUND(HttpStatus.NOT_FOUND, "여행 정보를 찾을 수 없습니다."),
 	ALREADY_INVITED(HttpStatus.CONFLICT, "이미 초대된 사용자입니다."),
+	CANNOT_INVITE_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 초대할 수 없습니다."),
 
 	// Record
 	RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"기록 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/triplog/trip/TripController.java
+++ b/src/main/java/com/triplog/trip/TripController.java
@@ -1,8 +1,5 @@
 package com.triplog.trip;
-import com.triplog.trip.dto.TripCreateRequest;
-import com.triplog.trip.dto.TripCreateResponse;
-import com.triplog.trip.dto.TripDetailResponse;
-import com.triplog.trip.dto.TripFindByUserResponse;
+import com.triplog.trip.dto.*;
 import com.triplog.user.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,5 +41,12 @@ public class TripController {
     public ResponseEntity<TripDetailResponse> getTripDetail(@PathVariable Long trip_id) {
         TripDetailResponse response = tripService.getTripDetail(trip_id);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/trip/{trip_id}/invite")
+    @Operation(summary = "동반자 초대", description = "사용자의 닉네임으로 여행에 동반자를 초대합니다.")
+    public ResponseEntity<String> inviteTrip(@PathVariable Long trip_id, @RequestBody @Valid TripInviteRequest request) {
+        tripService.inviteTrip(trip_id, request);
+        return ResponseEntity.ok("동반자 초대 완료");
     }
 }

--- a/src/main/java/com/triplog/trip/TripController.java
+++ b/src/main/java/com/triplog/trip/TripController.java
@@ -45,8 +45,9 @@ public class TripController {
 
     @PostMapping("/trip/{tripId}/invite")
     @Operation(summary = "동반자 초대", description = "사용자의 닉네임으로 여행에 동반자를 초대합니다.")
-    public ResponseEntity<String> inviteTrip(@PathVariable Long tripId, @RequestBody @Valid TripInviteRequest request) {
-        tripService.inviteTrip(tripId, request);
+    public ResponseEntity<String> inviteTrip(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long tripId, @RequestBody @Valid TripInviteRequest request) {
+        String username = userDetails.getUsername();
+        tripService.inviteTrip(username, tripId, request);
         return ResponseEntity.ok("동반자 초대 완료");
     }
 }

--- a/src/main/java/com/triplog/trip/TripController.java
+++ b/src/main/java/com/triplog/trip/TripController.java
@@ -36,17 +36,17 @@ public class TripController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/trip/{trip_id}")
+    @PostMapping("/trip/{tripId}")
     @Operation(summary = "여행 상세 조회", description = "각 여행의 상세 정보를 조회합니다.")
-    public ResponseEntity<TripDetailResponse> getTripDetail(@PathVariable Long trip_id) {
-        TripDetailResponse response = tripService.getTripDetail(trip_id);
+    public ResponseEntity<TripDetailResponse> getTripDetail(@PathVariable Long tripId) {
+        TripDetailResponse response = tripService.getTripDetail(tripId);
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/trip/{trip_id}/invite")
+    @PostMapping("/trip/{tripId}/invite")
     @Operation(summary = "동반자 초대", description = "사용자의 닉네임으로 여행에 동반자를 초대합니다.")
-    public ResponseEntity<String> inviteTrip(@PathVariable Long trip_id, @RequestBody @Valid TripInviteRequest request) {
-        tripService.inviteTrip(trip_id, request);
+    public ResponseEntity<String> inviteTrip(@PathVariable Long tripId, @RequestBody @Valid TripInviteRequest request) {
+        tripService.inviteTrip(tripId, request);
         return ResponseEntity.ok("동반자 초대 완료");
     }
 }

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -43,6 +43,7 @@ public class TripService {
                 .isPublic(request.isPublic())
                 .startDate(request.startDate())
                 .endDate(request.endDate())
+                .user(user)
                 .build();
 
         Trip savedTrip = tripRepository.save(trip);

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -92,10 +92,17 @@ public class TripService {
     }
 
     @Transactional
-    public void inviteTrip(Long tripId, TripInviteRequest request) {
+    public void inviteTrip(String username, Long tripId, TripInviteRequest request) {
+        User user = userFinder.findByNickname(username);
         Trip trip = tripFinder.findByTripId(tripId);
         User invitedUser = userFinder.findByNickname(request.nickname());
 
+        // 자기 자신 초대 방지
+        if (user.equals(invitedUser)){
+           throw new CustomException(ErrorCode.CANNOT_INVITE_SELF);
+        }
+
+        // 이미 초대된 유저인지 확인
         boolean alreadyInvited = tripParticipantRepository
                 .existsByTripAndUser(trip, invitedUser);
 

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -48,6 +48,7 @@ public class TripService {
         TripParticipant participant = TripParticipant.builder()
                 .user(user)
                 .trip(savedTrip)
+                .inviter(user.getNickname())
                 .isAccepted(true)
                 .build();
 
@@ -113,6 +114,7 @@ public class TripService {
         TripParticipant participant = TripParticipant.builder()
                 .user(invitedUser)
                 .trip(trip)
+                .inviter(user.getNickname())
                 .isAccepted(false)
                 .build();
 

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -85,15 +85,15 @@ public class TripService {
                 .build();
     }
 
-    public TripDetailResponse getTripDetail(Long trip_id) {
-        Trip trip = tripFinder.findByTripId(trip_id);
+    public TripDetailResponse getTripDetail(Long tripId) {
+        Trip trip = tripFinder.findByTripId(tripId);
         List<TripTag> tags = tripTagRepository.findByTrip(trip);
         return TripDetailResponse.from(trip, tags);
     }
 
     @Transactional
-    public void inviteTrip(Long trip_id, TripInviteRequest request) {
-        Trip trip = tripFinder.findByTripId(trip_id);
+    public void inviteTrip(Long tripId, TripInviteRequest request) {
+        Trip trip = tripFinder.findByTripId(tripId);
         User invitedUser = userFinder.findByNickname(request.nickname());
 
         boolean alreadyInvited = tripParticipantRepository

--- a/src/main/java/com/triplog/trip/domain/Trip.java
+++ b/src/main/java/com/triplog/trip/domain/Trip.java
@@ -1,10 +1,8 @@
 package com.triplog.trip.domain;
 
 import com.triplog.common.domain.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.triplog.user.domain.User;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,4 +31,8 @@ public class Trip extends BaseEntity {
     private LocalDate startDate;
 
     private LocalDate endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/src/main/java/com/triplog/trip/domain/TripParticipant.java
+++ b/src/main/java/com/triplog/trip/domain/TripParticipant.java
@@ -33,4 +33,6 @@ public class TripParticipant extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trip_id")
     private Trip trip;
+
+    private boolean isAccepted;
 }

--- a/src/main/java/com/triplog/trip/domain/TripParticipant.java
+++ b/src/main/java/com/triplog/trip/domain/TripParticipant.java
@@ -34,5 +34,6 @@ public class TripParticipant extends BaseEntity {
     @JoinColumn(name = "trip_id")
     private Trip trip;
 
+    private String inviter;
     private boolean isAccepted;
 }

--- a/src/main/java/com/triplog/trip/dto/TripInviteRequest.java
+++ b/src/main/java/com/triplog/trip/dto/TripInviteRequest.java
@@ -1,0 +1,4 @@
+package com.triplog.trip.dto;
+
+public record TripInviteRequest(String nickname) {
+}

--- a/src/main/java/com/triplog/trip/repository/TripParticipantRepository.java
+++ b/src/main/java/com/triplog/trip/repository/TripParticipantRepository.java
@@ -6,8 +6,9 @@ import com.triplog.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TripParticipantRepository extends JpaRepository<TripParticipant, Long> {
     List<TripParticipant> findByUser(User user);
     boolean existsByTripAndUser(Trip trip, User user);
-}
+    Optional<TripParticipant> findByTripAndUser(Trip trip, User user);}

--- a/src/main/java/com/triplog/trip/repository/TripParticipantRepository.java
+++ b/src/main/java/com/triplog/trip/repository/TripParticipantRepository.java
@@ -1,5 +1,6 @@
 package com.triplog.trip.repository;
 
+import com.triplog.trip.domain.Trip;
 import com.triplog.trip.domain.TripParticipant;
 import com.triplog.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,5 @@ import java.util.List;
 
 public interface TripParticipantRepository extends JpaRepository<TripParticipant, Long> {
     List<TripParticipant> findByUser(User user);
+    boolean existsByTripAndUser(Trip trip, User user);
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #44

## 💻 작업 내용
- [x] ~ Trip에 User 연관관계 추가(여행 생성 유저 저장 용도)
- [x] ~ 여행 생성 시 Trip에 여행 생성 유저 저장하도록 수정
- [x] ~ 동반자 초대 API 구현
- [x] ~ 동반자 초대 시 중복 확인

--- 추가 작업 내용입니다.
- [x] ~ 변수명, 엔드포인트 카멜케이스로 수정
- [x] ~ 본인 초대 방지 로직 및 초대자가 여행 참여자인지 확인하는 로직 추가
- [x] ~ TripParticipant에 inviter 변수 추가(여행 초대자 저장 용도)
- [x] ~ 여행 생성 시 inviter에 본인 추가, 동반자 초대 시 본인의 닉네임을 초대자로 저장하도록 수정

## ✅ PR Point
- Trip에 User 연관관계 추가, TripParticipant에 isAccepted, inviter 변수 추가하였습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
1. Trip에 여행 생성 유저 저장
![image](https://github.com/user-attachments/assets/6c234880-5cf9-4552-b4a0-abb58d19c3cd)
![image](https://github.com/user-attachments/assets/fec6be90-d615-4047-a5c8-955ca45c81a8)
![image](https://github.com/user-attachments/assets/0a2e40f7-b493-4640-9c9f-362536bdf5b7)

2. 동반자 초대
![image](https://github.com/user-attachments/assets/a9502fa8-17fd-4eaa-b195-f7f191fbf762)
![image](https://github.com/user-attachments/assets/2f25ceeb-24de-4c5d-b046-4c71e0a79e16)
![image](https://github.com/user-attachments/assets/7bd95d1f-560b-44fd-b7db-33b58e785e0b)

3. 동반자 초대 요청 중복 시
![image](https://github.com/user-attachments/assets/d5374a03-223f-46c3-a9d0-8fcd9eb73e8b)

4. 본인 초대 시
![image](https://github.com/user-attachments/assets/123f2edc-2e62-4720-88a1-89b2bab628a9)

5. 여행 참여자가 아닌데(요청을 수락하지 않은 경우 포함) 초대한 경우
![image](https://github.com/user-attachments/assets/014720a6-f391-4e73-bbb1-597d51d2b967)