### PR TITLE
[TRIP] 동반자 초대 거절 API 구현

### DIFF
--- a/src/main/java/com/triplog/trip/TripController.java
+++ b/src/main/java/com/triplog/trip/TripController.java
@@ -52,7 +52,7 @@ public class TripController {
     }
 
     @GetMapping("/invite")
-    @Operation(summary = "여행 초대 조회", description = "사용자가 받은 여행 초대를 조회합니다.")
+    @Operation(summary = "동반자 초대 조회", description = "사용자가 받은 여행 초대를 조회합니다.")
     public ResponseEntity<TripInviteFindByUserResponse> getTripInvitesByUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
         String username = userDetails.getUsername();
         TripInviteFindByUserResponse response = tripService.getTripInvitesByUser(username);
@@ -65,5 +65,13 @@ public class TripController {
         String username = userDetails.getUsername();
         tripService.acceptInvite(username, tripId);
         return ResponseEntity.ok("초대 수락 완료");
+    }
+
+    @DeleteMapping("{tripId}/invite/refuse")
+    @Operation(summary = "동반자 초대 거절", description = "사용자가 받은 여행 초대를 거절합니다.")
+    public ResponseEntity<String> refuseInvite(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long tripId) {
+        String username = userDetails.getUsername();
+        tripService.refuseInvite(username, tripId);
+        return ResponseEntity.ok("초대 거절 완료");
     }
 }

--- a/src/main/java/com/triplog/trip/TripService.java
+++ b/src/main/java/com/triplog/trip/TripService.java
@@ -156,4 +156,20 @@ public class TripService {
 
         tripParticipant.accept();
     }
+
+    @Transactional
+    public void refuseInvite(String username, Long tripId) {
+        User user = userFinder.findByNickname(username);
+        Trip trip = tripFinder.findByTripId(tripId);
+
+        TripParticipant tripParticipant = tripParticipantRepository
+                .findByTripAndUser(trip, user)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVITE_NOT_FOUND));
+
+        if (tripParticipant.isAccepted()) {
+            throw new CustomException(ErrorCode.ALREADY_ACCEPTED);
+        }
+
+        tripParticipantRepository.delete(tripParticipant);
+    }
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #51

## 💻 작업 내용
- [x] ~ 동반자 초대 거절 API 구현

## ✅ PR Point
- 이미 수락한 여행에 대해서는 거절하지 못하도록 처리하였습니다. 필요하다면 여행 탈퇴 API를 따로 구현하도록 하겠습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화
1. API test
![image](https://github.com/user-attachments/assets/a54a3eb0-a242-4c79-a063-6288a1b15ede)

2. DB test
(삭제 전)
![image](https://github.com/user-attachments/assets/1c04a75f-bb70-422f-bea5-0f9fea4d3591)
(삭제 후)
![image](https://github.com/user-attachments/assets/ed332777-87fb-4552-b16f-9cf2543b935f)

3. 예외처리
![image](https://github.com/user-attachments/assets/9358f406-0fae-4aa7-9b2b-be8c139e935b)